### PR TITLE
Bind to click event, not DOMSubtreeModified, other cleanup

### DIFF
--- a/google_calendar_clickable_where/clickable_where.user.js
+++ b/google_calendar_clickable_where/clickable_where.user.js
@@ -2,48 +2,20 @@
  * Created by Jonathan Falkner on 4/5/16.
  */
 
-w = unsafeWindow || window;
-
-w.clickable_where = {};
-
-w.clickable_where.DOMSubtreeModified_timer = null;
-w.clickable_where.DOMSubtreeModified_HandleChange = function (e) {
-    w.clickable_where.make_all_links_clickable_on_DOMSubtreeModified(e);
-};
-w.clickable_where.DOMSubtreeModified = function (e){
-    if (typeof w.clickable_where.DOMSubtreeModified_timer == "number") {
-        clearTimeout (w.clickable_where.DOMSubtreeModified_timer);
-        w.clickable_where.DOMSubtreeModified_timer = null;
-    }
-    w.clickable_where.DOMSubtreeModified_timer = setTimeout (
-        function () {
-            w.clickable_where.DOMSubtreeModified_HandleChange(e);
-        }, 100
-    );
-};
-
-
-w.clickable_where.main = function main () {
-    w.document.addEventListener('DOMSubtreeModified', w.clickable_where.DOMSubtreeModified);
-};
-
-w.clickable_where.remove_zero_width_spaces = function remove_zero_width_spaces(text){
-    return text.replace('&#8203;', '');
-};
-w.clickable_where.make_all_links_clickable_on_DOMSubtreeModified = function make_all_links_clickable_on_DOMSubtreeModified (e) {
-    w.clickable_where.make_all_links_clickable(e.path[0]);
-};
-
-w.clickable_where.make_all_links_clickable = function make_all_links_clickable (node) {
+window.make_child_links_clickable = function make_child_links_clickable (node) {
+    //console.log("Making child links clickable on tag:" + node.tagName + " id:" + node.id + " classList:" + node.classList);
     if (node.hasChildNodes()) {
         var exp = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/i;
         var nodes = node.childNodes;
         for (var i = 0, m = nodes.length; i < m; i++) {
+            //console.log(" Checking child node " + i); 
             var n = nodes[i];
             if (n.nodeType == n.TEXT_NODE) {
                 n.textContent = n.textContent.replace('&#8203;','').replace(/\u200B/g,'');
+                //console.log("  Found text node: " + n.textContent);
                 var g = n.textContent.match(exp);
                 while (g) {
+                    //console.log("   Found url match to replace.");
                     var idx = n.textContent.indexOf(g[0]);
                     var pre = n.textContent.substring(0, idx);
                     var t = document.createTextNode(pre);
@@ -57,34 +29,25 @@ w.clickable_where.make_all_links_clickable = function make_all_links_clickable (
                     g = n.textContent.match(exp);
                 }
             }
-            else if (n.tagName.toLowerCase() != 'a') {
-                w.clickable_where.make_all_links_clickable(n);
+            else if ((n.nodeType == n.ELEMENT_NODE) && (n.tagName.toLowerCase() != 'a')) {
+                window.make_child_links_clickable(n);
             }
         }
     }
 };
 
-if (typeof (opera) != "undefined") {
-    // Start the mainpart, if the site is loaded
-    window.addEventListener('DOMContentLoaded', w.clickable_where.main, true);
-} else {
-    w.clickable_where.main();
+function whereClickHandler(e) {
+    //console.log("Click Handler Fired");
+    // check for pop-up meeting info modal
+    nodes = window.document.querySelectorAll('.neb-break-words');
+    for (var i = 0, m = nodes.length; i < m; i++) {
+        window.make_child_links_clickable(nodes[i]);
+    }
+    // check for event detail
+    nodes = window.document.querySelectorAll('.ui-sch-schmedit');
+    for (var i = 0, m = nodes.length; i < m; i++) {
+        window.make_child_links_clickable(nodes[i]);
+    }
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-// Fix for user scripts not working in opera unless lots of end content exists at the end of the file.  This text is useful only in that it is very long and fills up a lot of space, ensuring that Opera will be able to load this user script.
+window.document.addEventListener('click', whereClickHandler);


### PR DESCRIPTION
Code wasn't working for me. Switching the trigger to the click event seemed much more stable. Also DOMSubtreeModified is going to be deprecated. I also focused the selector on just the elements which contained the "where" link content, not the whole document.